### PR TITLE
Update make.cmd: output labels as tests run

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -62,38 +62,38 @@ goto :exit
 
 :test-smoke
 pushd bin\v2Debug
-IronPythonTest.exe -include:StandardCPython -result:smoke-result-net35.xml
+IronPythonTest.exe --labels=All -include:StandardCPython -result:smoke-result-net35.xml
 popd
 pushd bin\Debug
-IronPythonTest.exe -include:StandardCPython -result:smoke-result-net40.xml
+IronPythonTest.exe --labels=All -include:StandardCPython -result:smoke-result-net40.xml
 popd
 pushd bin\v45Debug
-IronPythonTest.exe -include:StandardCPython -result:smoke-result-net45.xml
+IronPythonTest.exe --labels=All -include:StandardCPython -result:smoke-result-net45.xml
 popd
 goto :exit
 
 :test-ironpython
 pushd bin\Debug
-IronPythonTest.exe -include:IronPython -result:ironpython-result.xml
+IronPythonTest.exe --labels=All -include:IronPython -result:ironpython-result.xml
 popd
 goto :exit
 
 :test-cpython
 pushd bin\Debug
-IronPythonTest.exe -include:StandardCPython,AllCPython -result:cpython-result.xml
+IronPythonTest.exe --labels=All -include:StandardCPython,AllCPython -result:cpython-result.xml
 popd
 goto :exit
 
 :test-all
 pushd bin\Debug
-IronPythonTest.exe -result:all-result.xml
+IronPythonTest.exe --labels=All -result:all-result.xml
 popd
 goto :exit
 
 :test-custom
 pushd bin\Debug
 shift
-IronPythonTest.exe -result:custom-result.xml %1 %2 %3 %4 %5 %6 %7 %8 %9
+IronPythonTest.exe --labels=All -result:custom-result.xml %1 %2 %3 %4 %5 %6 %7 %8 %9
 popd
 goto :exit
 


### PR DESCRIPTION
As of NUnit 3.4, the ```--labels=All``` flag can be used to output the name of each test case as it runs (to StdErr in default text color)